### PR TITLE
Add support for declaring multiple pseudo selectors with the same style object

### DIFF
--- a/packages/core/src/helpers/media.ts
+++ b/packages/core/src/helpers/media.ts
@@ -12,7 +12,7 @@ export default function media(list: Query | string, style: Style): Style {
 export function query(list: Query): string {
   if (process.env.NODE_ENV !== 'production') {
     if (Object.keys(list).length === 0) {
-      console.warn('The media query is empty and will therefor be ignored. Prefer not having empty media queries');
+      console.warn('The media query is empty and will therefore be ignored. Prefer not having empty media queries');
     }
   }
 

--- a/packages/core/src/helpers/pseudo.spec.ts
+++ b/packages/core/src/helpers/pseudo.spec.ts
@@ -1,0 +1,30 @@
+import pseudo from './pseudo';
+
+describe('pseudo selector', () => {
+  it('can create a selector', () => {
+    const style = {
+      minWidth: '300px',
+    };
+
+    const target = pseudo(':hover', style);
+    const expected = {
+      ':hover': style,
+    };
+
+    expect(target).toEqual(expected);
+  });
+  it('can create multiple selectors with the same style', () => {
+    const style = {
+      minWidth: '300px',
+    };
+
+    const selectors = [':hover', ':last-child'];
+    const target = pseudo(selectors, style);
+    const expected = {
+      ':hover': style,
+      ':last-child': style,
+    };
+
+    expect(target).toEqual(expected);
+  });
+});

--- a/packages/core/src/helpers/pseudo.ts
+++ b/packages/core/src/helpers/pseudo.ts
@@ -3,7 +3,10 @@ import { Style } from '@glitz/type';
 // Unfortunately we need this until there's a way to have index signatures for
 // other types like: https://github.com/Microsoft/TypeScript/issues/7765.
 // This is a work around that works thanks to dynamic properties.
-export default function pseudo(value: string, style: Style): Style {
+
+export default function pseudo(selector: string | string[], style: Style): Style {
   // TODO Pseudo validation
-  return { [value]: style };
+  return typeof selector === 'string'
+    ? { [selector]: style }
+    : selector.reduce((acc, value) => ({ ...acc, [value]: style }), {});
 }


### PR DESCRIPTION
This PR allows you to do the following:

```js
const style: Style = {
  fontSize: 32,
  color: 'papayawhip'
}

const MyComp = styled.div({
  ...pseudo(':hover', style)
})

const MyOtherComp = styled.button({
  ...pseudo([':hover', ':active'], style)
})
```

Added 2 tests to cover the both the existing and the new feature, just in case 😄 