### PR TITLE
IE11 - Catch rules that fails when being applied

### DIFF
--- a/packages/core/src/utils/dom.ts
+++ b/packages/core/src/utils/dom.ts
@@ -3,8 +3,10 @@ export function injectSheetRule(styleElement: HTMLStyleElement, rule: string) {
   const index = sheet.cssRules.length;
   try {
     sheet.insertRule(rule, index);
-  } finally {
-    // Ignore failing rules
+  } catch (e) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`Failed to inject CSS: ${rule}`);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes an ie11 error that occurs when we inject style rules.
![error](https://user-images.githubusercontent.com/56259840/68209910-b10bc900-ffd4-11e9-8a86-26c76512c05d.PNG)


We now catch the error and display a warning in the console for developers.


