### PR TITLE
Removed legacy css property

### DIFF
--- a/packages/length-transformer/src/index.ts
+++ b/packages/length-transformer/src/index.ts
@@ -227,7 +227,6 @@ declare module '@glitz/core' {
     shapeMargin?: Glitz.Properties<LengthAndTime, LengthAndTime>['shapeMargin'];
     textDecoration?: Glitz.Properties<LengthAndTime, LengthAndTime>['textDecoration'];
     textDecorationThickness?: Glitz.Properties<LengthAndTime, LengthAndTime>['textDecorationThickness'];
-    textDecorationWidth?: Glitz.Properties<LengthAndTime, LengthAndTime>['textDecorationWidth'];
     textIndent?: Glitz.Properties<LengthAndTime, LengthAndTime>['textIndent'];
     textUnderlineOffset?: Glitz.Properties<LengthAndTime, LengthAndTime>['textUnderlineOffset'];
     top?: Glitz.Properties<LengthAndTime, LengthAndTime>['top'];


### PR DESCRIPTION
Removed textDecorationWidth as it is a legacy CSS property no longer available, conflicting with newer versions of the csstype package.