### PR TITLE
Add possibility to pass disallowedClassNames as option to avoid certain class names

### DIFF
--- a/packages/core/src/client/GlitzClient.ts
+++ b/packages/core/src/client/GlitzClient.ts
@@ -2,7 +2,7 @@ import { Globals, Style, Theme } from '../style';
 import { Base, createStyleInjectors } from '../core/create-style-injectors';
 import { DEFAULT_HYDRATION_IDENTIFIER, Options } from '../options';
 import { createStyleElement, insertStyleElement } from '../utils/dom';
-import { createHashCounter } from '../utils/hash';
+import { createHashCounter, createHashCountsFromStringList } from '../utils/hash';
 import InjectorClient from './InjectorClient';
 import { createHydrate } from '../utils/hydrate';
 
@@ -12,8 +12,9 @@ export default class GlitzClient<TStyle = Style> implements Base<TStyle> {
   public hydrate: (css: string) => void;
   constructor(options: Options = {}) {
     const prefix = options.prefix;
-    const classNameHash = createHashCounter(prefix);
-    const keyframesHash = createHashCounter(prefix);
+    const hashSkipList = createHashCountsFromStringList(options.classNameSkipList);
+    const classNameHash = createHashCounter(prefix, hashSkipList);
+    const keyframesHash = createHashCounter(prefix, hashSkipList);
 
     const mediaOrderOption = options.mediaOrder;
     const mediaSheets: { [media: string]: HTMLStyleElement } = {};

--- a/packages/core/src/client/GlitzClient.ts
+++ b/packages/core/src/client/GlitzClient.ts
@@ -12,7 +12,7 @@ export default class GlitzClient<TStyle = Style> implements Base<TStyle> {
   public hydrate: (css: string) => void;
   constructor(options: Options = {}) {
     const prefix = options.prefix;
-    const hashSkipList = createHashCountsFromStringList(options.classNameSkipList);
+    const hashSkipList = createHashCountsFromStringList(options.disallowedClassNames);
     const classNameHash = createHashCounter(prefix, hashSkipList);
     const keyframesHash = createHashCounter(prefix, hashSkipList);
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -9,4 +9,5 @@ export type Options = {
   transformer?: Transformer;
   mediaOrder?: (a: string, b: string) => number;
   prefix?: string;
+  classNameSkipList?: string[];
 };

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -9,5 +9,5 @@ export type Options = {
   transformer?: Transformer;
   mediaOrder?: (a: string, b: string) => number;
   prefix?: string;
-  classNameSkipList?: string[];
+  disallowedClassNames?: string[];
 };

--- a/packages/core/src/server/GlitzServer.ts
+++ b/packages/core/src/server/GlitzServer.ts
@@ -1,7 +1,7 @@
 import { Globals, Style, Theme } from '../style';
 import { Base, createStyleInjectors } from '../core/create-style-injectors';
 import { DEFAULT_HYDRATION_IDENTIFIER, Options } from '../options';
-import { createHashCounter } from '../utils/hash';
+import { createHashCounter, createHashCountsFromStringList } from '../utils/hash';
 import InjectorServer from './InjectorServer';
 import { createHydrate } from '../utils/hydrate';
 import { formatMediaRule } from '../utils/format';
@@ -25,8 +25,8 @@ export default class GlitzServer<TStyle = Style> implements Base<TStyle> {
   constructor(options?: Options);
   constructor(
     options: Options = {},
-    classNameHash = createHashCounter(options.prefix),
-    keyframesHash = createHashCounter(options.prefix),
+    classNameHash = createHashCounter(options.prefix, createHashCountsFromStringList(options.classNameSkipList)),
+    keyframesHash = createHashCounter(options.prefix, createHashCountsFromStringList(options.classNameSkipList)),
     plainInjector?: InjectorServer,
     mediaInjectors: Record<string, InjectorServer> = {},
   ) {

--- a/packages/core/src/server/GlitzServer.ts
+++ b/packages/core/src/server/GlitzServer.ts
@@ -25,8 +25,8 @@ export default class GlitzServer<TStyle = Style> implements Base<TStyle> {
   constructor(options?: Options);
   constructor(
     options: Options = {},
-    classNameHash = createHashCounter(options.prefix, createHashCountsFromStringList(options.classNameSkipList)),
-    keyframesHash = createHashCounter(options.prefix, createHashCountsFromStringList(options.classNameSkipList)),
+    classNameHash = createHashCounter(options.prefix, createHashCountsFromStringList(options.disallowedClassNames)),
+    keyframesHash = createHashCounter(options.prefix, createHashCountsFromStringList(options.disallowedClassNames)),
     plainInjector?: InjectorServer,
     mediaInjectors: Record<string, InjectorServer> = {},
   ) {

--- a/packages/core/src/utils/hash.spec.ts
+++ b/packages/core/src/utils/hash.spec.ts
@@ -1,4 +1,4 @@
-import { createHashCounter } from './hash';
+import { createHashCounter, createHashCountsFromStringList } from './hash';
 
 describe('hash', () => {
   it('increments', () => {
@@ -31,5 +31,10 @@ describe('hash', () => {
     const counterB = counterA.clone();
     expect(counterA()).toBe('b');
     expect(counterB()).toBe('b');
+  });
+  it('skips skip list', () => {
+    const skipList = createHashCountsFromStringList(['a']);
+    const counter = createHashCounter(undefined, skipList);
+    expect(counter()).toBe('b');
   });
 });

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -3,7 +3,7 @@ export type HashCounter = {
   clone(): HashCounter;
 };
 
-export function createHashCounter(prefix = '', count = 0, offset = 10, msb = 35, power = 1): HashCounter {
+export function createHashCounter(prefix = '', skipList: number[] = [], count = 0, offset = 10, msb = 35, power = 1): HashCounter {
   function increment(): string {
     const virtualCount = count + offset;
 
@@ -15,7 +15,7 @@ export function createHashCounter(prefix = '', count = 0, offset = 10, msb = 35,
     count++;
 
     // Skip "ad" due to ad-blockers
-    if (virtualCount === 373) {
+    if (virtualCount === 373 || skipList.findIndex(s => s === virtualCount) > -1) {
       return increment();
     }
 
@@ -24,7 +24,11 @@ export function createHashCounter(prefix = '', count = 0, offset = 10, msb = 35,
 
   return Object.assign(increment, {
     clone() {
-      return createHashCounter(prefix, count, offset, msb, power);
+      return createHashCounter(prefix, skipList, count, offset, msb, power);
     },
   });
+}
+
+export function createHashCountsFromStringList(classNameSkipList: string[] = []) {
+  return classNameSkipList.map(c => parseInt(c, 36));
 }

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -15,7 +15,7 @@ export function createHashCounter(prefix = '', skipList: number[] = [], count = 
     count++;
 
     // Skip "ad" due to ad-blockers
-    if (virtualCount === 373 || skipList.findIndex(s => s === virtualCount) > -1) {
+    if (virtualCount === 373 || skipList.indexOf(virtualCount) > -1) {
       return increment();
     }
 

--- a/packages/core/src/utils/hash.ts
+++ b/packages/core/src/utils/hash.ts
@@ -29,6 +29,6 @@ export function createHashCounter(prefix = '', skipList: number[] = [], count = 
   });
 }
 
-export function createHashCountsFromStringList(classNameSkipList: string[] = []) {
-  return classNameSkipList.map(c => parseInt(c, 36));
+export function createHashCountsFromStringList(disallowedClassNames: string[] = []) {
+  return disallowedClassNames.map(c => parseInt(c, 36));
 }


### PR DESCRIPTION
Sometimes generated class names clash with those from third party vendors causing unwanted side effects. This PR makes it possible to pass a list of strings that should be skipped by the `createHashCounter` function, simliar to the already existing `ad` exception.

Placing the `skipList` argument as the second parameter might make this a breaking change (if used by other projects).